### PR TITLE
Allow configuration of arbitrary key/value pairs in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Attributes
 | `['sssd_conf']['ldap_tls_cacert']` | `'/etc/pki/tls/certs/ca-bundle.crt'` or `'/etc/ssl/certs/ca-certificates.crt'` | defaults for RHEL and others respectively |
 | `['sssd_conf']['ldap_default_bind_dn']` | `'cn=bindaccount,dc=yourcompany,dc=com'` | if you have a domain that doesn't require binding set this attributes to nil
 | `['sssd_conf']['ldap_default_authtok']` | `'bind_password'` | if you have a domain that doesn't require binding set this to nil | 
-| `['sssd_conf']['authconfig_params']` | `'--enablesssd --enablesssdauth --enablelocauthorize --update'` | |
+| `['authconfig_params']` | `'--enablesssd --enablesssdauth --enablelocauthorize --update'` | |
 | `['sssd_conf']['access_provider']` | `nil` | Should be set to `'ldap'` |
-| `['sssd_conf']['ldap_access_filter']` | nil| Can use simple LDAP filter such as `'uid=abc123'` or more expressive LDAP filters like `'(&(objectClass=employee)(department=ITSupport))'` | 
+| `['sssd_conf']['ldap_access_filter']` | `nil`| Can use simple LDAP filter such as `'uid=abc123'` or more expressive LDAP filters like `'(&(objectClass=employee)(department=ITSupport))'` | 
 | `['sssd_conf']['min_id']` | `'1'` | default, used to ignore lower uid/gid's | 
 | `['sssd_conf']['max_id']` | `'0'` | default, used to ignore higher uid/gid's | 
-| `['sssd_conf']['ldap_sudo']` | `false` | Adds ldap enabled sudoers (true/false) |
+| `['ldap_sudo']` | `false` | Adds ldap enabled sudoers (true/false) |
 
 
 Recipes

--- a/README.md
+++ b/README.md
@@ -20,33 +20,33 @@ Attributes
 ----------
 | Attribute | Value | Comment |
 | -------------  | -------------  | -------------  |
-| ['id_provider'] | 'ldap' | |
-| ['auth_provider'] | 'ldap' | |
-| ['chpass_provider'] | 'ldap' | |
-| ['sudo_provider'] | 'ldap' | | 
-| ['enumerate'] | 'true' | |
-| ['cache_credentials'] | 'false' | |
-| ['ldap_schema'] | 'rfc2307bis' | |
-| ['ldap_uri'] | 'ldap://something.yourcompany.com' | |
-| ['ldap_search_base'] | 'dc=yourcompany,dc=com' | |
-| ['ldap_user_search_base'] | 'ou=People,dc=yourcompany,dc=com' | |
-| ['ldap_user_object_class'] | 'posixAccount' | |
-| ['ldap_user_name'] | 'uid' | |
-| ['override_homedir'] | nil | |
-| ['shell_fallback'] | '/bin/bash' | |
-| ['ldap_group_search_base'] | 'ou=Groups,dc=yourcompany,dc=com' | |
-| ['ldap_group_object_class'] | 'posixGroup' | |
-| ['ldap_id_use_start_tls'] | 'true' | |
-| ['ldap_tls_reqcert'] | 'never' | |
-| ['ldap_tls_cacert'] | '/etc/pki/tls/certs/ca-bundle.crt' or '/etc/ssl/certs/ca-certificates.crt' | defaults for RHEL and others respectively |
-| ['ldap_default_bind_dn'] | 'cn=bindaccount,dc=yourcompany,dc=com' | if you have a domain that doesn't require binding set this attributes to nil
-| ['ldap_default_authtok'] | 'bind_password' | if you have a domain that doesn't require binding set this to nil | 
-| ['authconfig_params'] | '--enablesssd --enablesssdauth --enablelocauthorize --update' | |
-| ['access_provider'] | nil | Should be set to 'ldap' |
-| ['ldap_access_filter'] | nil| Can use simple LDAP filter such as 'uid=abc123' or more expressive LDAP filters like '(&(objectClass=employee)(department=ITSupport))' | 
-| ['min_id'] | '1' | default, used to ignore lower uid/gid's | 
-| ['max_id'] | '0' | default, used to ignore higher uid/gid's | 
-| ['ldap_sudo'] | false | Adds ldap enabled sudoers (true/false) |
+| `['sssd_conf']['id_provider']` | `'ldap'` | |
+| `['sssd_conf']['auth_provider']` | `'ldap'` | |
+| `['sssd_conf']['chpass_provider']` | `'ldap'` | |
+| `['sssd_conf']['sudo_provider']` | `'ldap'` | | 
+| `['sssd_conf']['enumerate']` | `'true'` | |
+| `['sssd_conf']['cache_credentials']` | `'false'` | |
+| `['sssd_conf']['ldap_schema']` | `'rfc2307bis'` | |
+| `['sssd_conf']['ldap_uri']` | `'ldap://something.yourcompany.com'` | |
+| `['sssd_conf']['ldap_search_base']` | `'dc=yourcompany,dc=com'` | |
+| `['sssd_conf']['ldap_user_search_base']` | `'ou=People,dc=yourcompany,dc=com'` | |
+| `['sssd_conf']['ldap_user_object_class']` | `'posixAccount'` | |
+| `['sssd_conf']['ldap_user_name']` | `'uid'` | |
+| `['sssd_conf']['override_homedir']` | `nil` | |
+| `['sssd_conf']['shell_fallback']` | `'/bin/bash'` | |
+| `['sssd_conf']['ldap_group_search_base']` | `'ou=Groups,dc=yourcompany,dc=com'` | |
+| `['sssd_conf']['ldap_group_object_class']` | `'posixGroup'` | |
+| `['sssd_conf']['ldap_id_use_start_tls']` | `'true'` | |
+| `['sssd_conf']['ldap_tls_reqcert']` | `'never'` | |
+| `['sssd_conf']['ldap_tls_cacert']` | `'/etc/pki/tls/certs/ca-bundle.crt'` or `'/etc/ssl/certs/ca-certificates.crt'` | defaults for RHEL and others respectively |
+| `['sssd_conf']['ldap_default_bind_dn']` | `'cn=bindaccount,dc=yourcompany,dc=com'` | if you have a domain that doesn't require binding set this attributes to nil
+| `['sssd_conf']['ldap_default_authtok']` | `'bind_password'` | if you have a domain that doesn't require binding set this to nil | 
+| `['sssd_conf']['authconfig_params']` | `'--enablesssd --enablesssdauth --enablelocauthorize --update'` | |
+| `['sssd_conf']['access_provider']` | `nil` | Should be set to `'ldap'` |
+| `['sssd_conf']['ldap_access_filter']` | nil| Can use simple LDAP filter such as `'uid=abc123'` or more expressive LDAP filters like `'(&(objectClass=employee)(department=ITSupport))'` | 
+| `['sssd_conf']['min_id']` | `'1'` | default, used to ignore lower uid/gid's | 
+| `['sssd_conf']['max_id']` | `'0'` | default, used to ignore higher uid/gid's | 
+| `['sssd_conf']['ldap_sudo']` | `false` | Adds ldap enabled sudoers (true/false) |
 
 
 Recipes

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Requirements
 
 Attributes
 ----------
+
+Arbitrary key/value pairs may be added to the `['sssd_conf']` attribute
+object.  These key/values will be expanded in the domain block of
+`sssd.conf`.  This allows you to set any SSSD configuration value you
+want, not just ones provided by the attributes in this cookbook.
+
 | Attribute | Value | Comment |
 | -------------  | -------------  | -------------  |
 | `['sssd_conf']['id_provider']` | `'ldap'` | |

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,39 +17,39 @@
 # limitations under the License.
 #
 
-default['sssd_ldap']['id_provider'] = 'ldap'
-default['sssd_ldap']['auth_provider'] = 'ldap'
-default['sssd_ldap']['chpass_provider'] = 'ldap'
-default['sssd_ldap']['sudo_provider'] = 'ldap'
-default['sssd_ldap']['enumerate'] = 'true'
-default['sssd_ldap']['cache_credentials'] = 'false'
+default['sssd_ldap']['sssd_conf']['id_provider'] = 'ldap'
+default['sssd_ldap']['sssd_conf']['auth_provider'] = 'ldap'
+default['sssd_ldap']['sssd_conf']['chpass_provider'] = 'ldap'
+default['sssd_ldap']['sssd_conf']['sudo_provider'] = 'ldap'
+default['sssd_ldap']['sssd_conf']['enumerate'] = 'true'
+default['sssd_ldap']['sssd_conf']['cache_credentials'] = 'false'
 
-default['sssd_ldap']['ldap_schema'] = 'rfc2307bis'
-default['sssd_ldap']['ldap_uri'] = 'ldap://something.yourcompany.com'
-default['sssd_ldap']['ldap_search_base'] = 'dc=yourcompany,dc=com'
-default['sssd_ldap']['ldap_user_search_base'] = 'ou=People,dc=yourcompany,dc=com'
-default['sssd_ldap']['ldap_user_object_class'] = 'posixAccount'
-default['sssd_ldap']['ldap_user_name'] = 'uid'
-default['sssd_ldap']['override_homedir'] = nil
-default['sssd_ldap']['shell_fallback'] = '/bin/bash'
+default['sssd_ldap']['sssd_conf']['ldap_schema'] = 'rfc2307bis'
+default['sssd_ldap']['sssd_conf']['ldap_uri'] = 'ldap://something.yourcompany.com'
+default['sssd_ldap']['sssd_conf']['ldap_search_base'] = 'dc=yourcompany,dc=com'
+default['sssd_ldap']['sssd_conf']['ldap_user_search_base'] = 'ou=People,dc=yourcompany,dc=com'
+default['sssd_ldap']['sssd_conf']['ldap_user_object_class'] = 'posixAccount'
+default['sssd_ldap']['sssd_conf']['ldap_user_name'] = 'uid'
+default['sssd_ldap']['sssd_conf']['override_homedir'] = nil
+default['sssd_ldap']['sssd_conf']['shell_fallback'] = '/bin/bash'
 
-default['sssd_ldap']['ldap_group_search_base'] = 'ou=Groups,dc=yourcompany,dc=com'
-default['sssd_ldap']['ldap_group_object_class'] = 'posixGroup'
-default['sssd_ldap']['ldap_group_name'] = 'cn'
+default['sssd_ldap']['sssd_conf']['ldap_group_search_base'] = 'ou=Groups,dc=yourcompany,dc=com'
+default['sssd_ldap']['sssd_conf']['ldap_group_object_class'] = 'posixGroup'
+default['sssd_ldap']['sssd_conf']['ldap_group_name'] = 'cn'
 
-default['sssd_ldap']['ldap_id_use_start_tls'] = 'true'
-default['sssd_ldap']['ldap_tls_reqcert'] = 'never'
-default['sssd_ldap']['ldap_tls_cacert'] = value_for_platform_family('rhel' => '/etc/pki/tls/certs/ca-bundle.crt', 'default' => '/etc/ssl/certs/ca-certificates.crt')
+default['sssd_ldap']['sssd_conf']['ldap_id_use_start_tls'] = 'true'
+default['sssd_ldap']['sssd_conf']['ldap_tls_reqcert'] = 'never'
+default['sssd_ldap']['sssd_conf']['ldap_tls_cacert'] = value_for_platform_family('rhel' => '/etc/pki/tls/certs/ca-bundle.crt', 'default' => '/etc/ssl/certs/ca-certificates.crt')
 
 # if you have a domain that doesn't require binding set these two attributes to nil
-default['sssd_ldap']['ldap_default_bind_dn'] = 'cn=bindaccount,dc=yourcompany,dc=com'
-default['sssd_ldap']['ldap_default_authtok'] = 'bind_password'
+default['sssd_ldap']['sssd_conf']['ldap_default_bind_dn'] = 'cn=bindaccount,dc=yourcompany,dc=com'
+default['sssd_ldap']['sssd_conf']['ldap_default_authtok'] = 'bind_password'
 
 default['sssd_ldap']['authconfig_params'] = '--enablesssd --enablesssdauth --enablelocauthorize --update'
 
-default['sssd_ldap']['access_provider'] = nil # Should be set to 'ldap'
-default['sssd_ldap']['ldap_access_filter'] = nil # Can use simple LDAP filter such as 'uid=abc123' or more expressive LDAP filters like '(&(objectClass=employee)(department=ITSupport))'
+default['sssd_ldap']['sssd_conf']['access_provider'] = nil # Should be set to 'ldap'
+default['sssd_ldap']['sssd_conf']['ldap_access_filter'] = nil # Can use simple LDAP filter such as 'uid=abc123' or more expressive LDAP filters like '(&(objectClass=employee)(department=ITSupport))'
 
-default['sssd_ldap']['min_id'] = '1'
-default['sssd_ldap']['max_id'] = '0'
+default['sssd_ldap']['sssd_conf']['min_id'] = '1'
+default['sssd_ldap']['sssd_conf']['max_id'] = '0'
 default['sssd_ldap']['ldap_sudo'] = false

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -9,40 +9,6 @@ filter_users = root,named,avahi,haldaemon,dbus,radiusd,news,nscd
 [pam]
 
 [domain/LDAP]
-auth_provider = <%= node['sssd_ldap']['auth_provider'] %>
-chpass_provider = <%= node['sssd_ldap']['chpass_provider'] %>
-<% if node['sssd_ldap']['ldap_sudo'] %>sudo_provider = <%= node['sssd_ldap']['sudo_provider'] %><% end %>
-id_provider = <%= node['sssd_ldap']['id_provider'] %>
-cache_credentials = <%= node['sssd_ldap']['cache_credentials'] %>
-enumerate = <%= node['sssd_ldap']['enumerate'] %>
-
-ldap_schema = <%= node['sssd_ldap']['ldap_schema'] %>
-ldap_uri = <%= node['sssd_ldap']['ldap_uri'] %>
-
-ldap_tls_reqcert = <%= node['sssd_ldap']['ldap_tls_reqcert'] %>
-ldap_tls_cacert = <%= node['sssd_ldap']['ldap_tls_cacert'] %>
-ldap_id_use_start_tls = <%= node['sssd_ldap']['ldap_id_use_start_tls'] %>
-
-ldap_search_base = <%= node['sssd_ldap']['ldap_search_base'] %>
-ldap_user_search_base = <%= node['sssd_ldap']['ldap_user_search_base'] %>
-ldap_user_object_class = <%= node['sssd_ldap']['ldap_user_object_class'] %>
-ldap_user_name = <%= node['sssd_ldap']['ldap_user_name'] %>
-<% if node['sssd_ldap']['override_homedir'] %>
-override_homedir = <%= node['sssd_ldap']['override_homedir'] %>
-<% end %>
-shell_fallback = <%= node['sssd_ldap']['shell_fallback'] %>
-
-ldap_group_search_base = <%= node['sssd_ldap']['ldap_group_search_base'] %>
-ldap_group_object_class = <%= node['sssd_ldap']['ldap_group_object_class'] %>
-ldap_group_name = <%= node['sssd_ldap']['ldap_group_name'] %>
-
-<% if node['sssd_ldap']['ldap_default_bind_dn'] %>ldap_default_bind_dn = <%= node['sssd_ldap']['ldap_default_bind_dn'] %><% end %>
-<% if node['sssd_ldap']['ldap_default_authtok'] %>ldap_default_authtok = <%= node['sssd_ldap']['ldap_default_authtok'] %><% end %>
-
-<% if node['sssd_ldap']['ldap_access_filter'] %>
-access_provider = <%= node['sssd_ldap']['access_provider'] %>
-ldap_access_filter = <%= node['sssd_ldap']['ldap_access_filter'] %>
-<% end %>
-
-min_id = <%= node['sssd_ldap']['min_id'] %>
-max_id = <%= node['sssd_ldap']['max_id'] %>
+<% node['sssd_ldap'].each do |key, value| %>
+<%=  key %> = <%= value %>
+<%end %>

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -9,6 +9,6 @@ filter_users = root,named,avahi,haldaemon,dbus,radiusd,news,nscd
 [pam]
 
 [domain/LDAP]
-<% node['sssd_ldap'].each do |key, value| %>
+<% node['sssd_ldap']['sssd_conf'].each do |key, value| %>
 <%=  key %> = <%= value %>
 <%end %>


### PR DESCRIPTION
The current template doesn't support many configuration values that are supported in `sssd.conf` by recent versions of SSSD.  This PR allows a user to set arbitrary key/value pairs in the `sssd.conf` template instead of only the keys that are currently hard-coded into the template.  The README has also been updated to reflect the changes.

Minor formatting fixes were also applied to the README.

Changes were verified against the Chefspec tests.