### PR TITLE
No nil entries in sssd.conf, enablement of ssh/autofs services

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Attribute                                  | Value                              
 `['sssd_conf']['min_id']`                  | `'1'`                                                                          | default, used to ignore lower uid/gid's
 `['sssd_conf']['max_id']`                  | `'0'`                                                                          | default, used to ignore higher uid/gid's
 `['ldap_sudo']`                            | `false`                                                                        | Adds ldap enabled sudoers (true/false)
+`['ldap_ssh']`                             | `false`                                                                        | Adds ldap enabled ssh keys (true/false)
+`['ldap_autofs']`                          | `false`                                                                        | Adds ldap enabled autofs config (true/false)
 
 ## Recipes
 - default: Installs and configures sssd daemon

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,3 +53,6 @@ default['sssd_ldap']['sssd_conf']['ldap_access_filter'] = nil # Can use simple L
 default['sssd_ldap']['sssd_conf']['min_id'] = '1'
 default['sssd_ldap']['sssd_conf']['max_id'] = '0'
 default['sssd_ldap']['ldap_sudo'] = false
+default['sssd_ldap']['ldap_autofs'] = false
+default['sssd_ldap']['ldap_ssh'] = false
+

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -10,5 +10,5 @@ filter_users = root,named,avahi,haldaemon,dbus,radiusd,news,nscd
 
 [domain/LDAP]
 <% node['sssd_ldap']['sssd_conf'].each do |key, value| %>
-<%=  key %> = <%= value %>
-<%end %>
+<% if not value.nil? %><%=  key %> = <%= value %><% end %>
+<% end %>

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -1,6 +1,6 @@
 [sssd]
 config_file_version = 2
-services = nss, pam<% if node['sssd_ldap']['ldap_autofs'] %>, sudo<% end %><% if node['sssd_ldap']['ldap_ssh'] %>, sudo<% end %><% if node['sssd_ldap']['ldap_sudo'] %>, sudo<% end %>
+services = nss, pam<% if node['sssd_ldap']['ldap_autofs'] %>, autofs<% end %><% if node['sssd_ldap']['ldap_ssh'] %>, ssh<% end %><% if node['sssd_ldap']['ldap_sudo'] %>, sudo<% end %>
 domains = LDAP
 
 [nss]

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -1,6 +1,6 @@
 [sssd]
 config_file_version = 2
-services = nss, pam<% if node['sssd_ldap']['ldap_sudo'] %>, sudo<% end %>
+services = nss, pam<% if node['sssd_ldap']['ldap_autofs'] %>, sudo<% end %><% if node['sssd_ldap']['ldap_ssh'] %>, sudo<% end %><% if node['sssd_ldap']['ldap_sudo'] %>, sudo<% end %>
 domains = LDAP
 
 [nss]


### PR DESCRIPTION
The patch does two things;

1) When generating the sssd.conf file, skill over any entry where the value is nil. This lets one for example, disable binding to the ldap server if so desired, or disable other config items.

2) Adds two new toggles for enabling services for ssh and autofs. No other configuration for these two items is done, it simply allows one to do so themselves if they like.
